### PR TITLE
fix redundant func in image pre-process

### DIFF
--- a/prj_ncnn/cpp/DBface.cpp
+++ b/prj_ncnn/cpp/DBface.cpp
@@ -60,21 +60,20 @@ int DBface::pre_process(ncnn::Mat image, ncnn::Mat &out) {
         ncnn::resize_bilinear(image, in, fixed_w, fixed_h);
     }
 
-    int c, h, w;
-    c = in.c;
-    h = in.h;
-    w = in.w;
-    float *data = (float *)(in.data);
+    in.substract_mean_normalize(mean_value, std_value);
 
-    for (int i = 0; i < c; ++i) {
-        for (int j = 0; j < h; ++j) {
-            for (int k = 0; k < w; ++k) {
-                data[i*h*w + j*w + k] /= 255;
+#ifdef DEBUG
+    {
+        for (int c = 0; c < in.c; c++)
+        {
+            const ncnn::Mat m = in.channel(c);
+            const float* ptr = m.row(0);
+            {
+                printf("in %d %f\n", 0, ptr[0]);
             }
         }
     }
-
-    in.substract_mean_normalize(mean_value, std_value);
+#endif
 
     image_h = in.h;
     image_w = in.w;

--- a/prj_ncnn/cpp/DBface.h
+++ b/prj_ncnn/cpp/DBface.h
@@ -28,8 +28,8 @@ class DBface{
 
     ncnn::Net net;
 
-    const float mean_value[3] = {0.408f, 0.447f, 0.47f};
-    const float std_value[3] = {1/0.289f, 1/0.274f, 1/0.278f};
+    const float mean_value[3] = {0.408f * 255.0, 0.447f * 255.0, 0.47f * 255.0};
+    const float std_value[3] = {1 / 0.289f / 255.0, 1 / 0.274f / 255.0, 1 / 0.278f / 255.0};
     int fixed_h = 2220;            // for fixed size inference
     int fixed_w = 3072;
     float fix_scale_h = 1.f;


### PR DESCRIPTION
Hi, I find a little bit to speed up the code
fix the redundant func in image pre-process to make it more efficient...
the test result below:
```
ori:
$ make && ./demo ../model/test.jpg
Scanning dependencies of target demo
[ 33%] Building CXX object CMakeFiles/demo.dir/cpp/DBface.cpp.o
[ 66%] Linking CXX executable demo
[100%] Built target demo
in 0 0.028716
in 0 0.068198
in 0 0.174478

current:
$ make && ./demo ../model/test.jpg
Scanning dependencies of target demo
[ 33%] Building CXX object CMakeFiles/demo.dir/cpp/DBface.cpp.o
[ 66%] Building CXX object CMakeFiles/demo.dir/demo.cpp.o
[100%] Linking CXX executable demo
[100%] Built target demo
in 0 0.028716
in 0 0.068198
in 0 0.174478
```

which has same results, but it didn't to enumerate all input image by 
```
for (int i = 0; i < c; ++i) {
        for (int j = 0; j < h; ++j) {
            for (int k = 0; k < w; ++k) {
```

